### PR TITLE
Add getRTLTextPluginStatus method to documentation config file.

### DIFF
--- a/docs/documentation.yml
+++ b/docs/documentation.yml
@@ -7,6 +7,7 @@ toc:
   - supported
   - version
   - setRTLTextPlugin
+  - getRTLTextPluginStatus
   - clearStorage
   - AnimationOptions
   - CameraOptions


### PR DESCRIPTION
Partially fixes #131 

I added getRTLTextPluginStatus to documentation.yml to move it to right section in API reference.