### PR TITLE
Link to camera glossary entry in set-perspective example

### DIFF
--- a/docs/pages/example/set-perspective.html
+++ b/docs/pages/example/set-perspective.html
@@ -3,6 +3,7 @@
 var map = new mapboxgl.Map({
     container: 'map',
     style: 'mapbox://styles/mapbox/streets-v11',
+    // camera options properties - https://docs.mapbox.com/help/glossary/camera/
     center: [-73.5804, 45.534830],
     pitch: 60, // pitch in degrees
     bearing: -60, // bearing in degrees


### PR DESCRIPTION
Fixes https://github.com/mapbox/mapbox-gl-js-docs/issues/140. Since neither the example itself nor the `CameraOptions` [documentation](https://docs.mapbox.com/mapbox-gl-js/api/#cameraoptions) in the API reference link to the glossary entry where the `pitch` and `bearing` properties are defined in detail, it is worthwhile to add a link.

In the long run, however, I'm not sure that adding links with inline comments is the best form. 