### PR TITLE
Fix references with '#' characters

### DIFF
--- a/docs/components/api-item-member.js
+++ b/docs/components/api-item-member.js
@@ -11,7 +11,6 @@ const linkerStack = new LinkerStack({}).namespaceResolver(docs, namespace => {
     const slugger = new GithubSlugger();
     const names = namespace.split('#');
     const nv = names.map((v) => `#${slugger.slug(v)}`).join('');
-    console.log(`slugger transformed ${namespace} to ${nv}`);
     return nv;
 });
 

--- a/docs/components/api-item-member.js
+++ b/docs/components/api-item-member.js
@@ -9,7 +9,10 @@ import Icon from '@mapbox/mr-ui/icon';
 
 const linkerStack = new LinkerStack({}).namespaceResolver(docs, namespace => {
     const slugger = new GithubSlugger();
-    return `#${slugger.slug(namespace)}`;
+    const names = namespace.split('#');
+    const nv = names.map((v) => `#${slugger.slug(v)}`).join('');
+    console.log(`slugger transformed ${namespace} to ${nv}`);
+    return nv;
 });
 
 const formatters = createFormatters(linkerStack.link);

--- a/docs/components/api-item.js
+++ b/docs/components/api-item.js
@@ -14,7 +14,6 @@ const linkerStack = new LinkerStack({}).namespaceResolver(docs, namespace => {
     const slugger = new GithubSlugger();
     const names = namespace.split('#');
     const nv = names.map((v) => `#${slugger.slug(v)}`).join('');
-    console.log(`slugger transformed ${namespace} to ${nv}`);
     return nv;
 });
 

--- a/docs/components/api-item.js
+++ b/docs/components/api-item.js
@@ -12,7 +12,10 @@ import constants from '../constants';
 
 const linkerStack = new LinkerStack({}).namespaceResolver(docs, namespace => {
     const slugger = new GithubSlugger();
-    return `#${slugger.slug(namespace)}`;
+    const names = namespace.split('#');
+    const nv = names.map((v) => `#${slugger.slug(v)}`).join('');
+    console.log(`slugger transformed ${namespace} to ${nv}`);
+    return nv;
 });
 
 const formatters = createFormatters(linkerStack.link);

--- a/docs/pages/api.js
+++ b/docs/pages/api.js
@@ -13,15 +13,18 @@ import PageShell from '../components/page_shell';
 import { prefixUrl } from '@mapbox/batfish/modules/prefix-url';
 import { version } from '../../mapbox-gl-js/package.json';
 import docs from '../components/api.json'; // eslint-disable-line
+import LinkerStack from 'documentation/src/output/util/linker_stack';
 import GithubSlugger from 'github-slugger';
 import createFormatters from 'documentation/src/output/util/formatters';
-import LinkerStack from 'documentation/src/output/util/linker_stack';
 import ApiItem from '../components/api-item';
 import DrUiNote from '@mapbox/dr-ui/note';
 
 const linkerStack = new LinkerStack({}).namespaceResolver(docs, namespace => {
     const slugger = new GithubSlugger();
-    return `#${slugger.slug(namespace)}`;
+    const names = namespace.split('#');
+    const nv = names.map((v) => `#${slugger.slug(v)}`).join('');
+    console.log(`slugger transformed ${namespace} to ${nv}`);
+    return nv;
 });
 
 const formatters = createFormatters(linkerStack.link);

--- a/docs/pages/api.js
+++ b/docs/pages/api.js
@@ -23,7 +23,6 @@ const linkerStack = new LinkerStack({}).namespaceResolver(docs, namespace => {
     const slugger = new GithubSlugger();
     const names = namespace.split('#');
     const nv = names.map((v) => `#${slugger.slug(v)}`).join('');
-    console.log(`slugger transformed ${namespace} to ${nv}`);
     return nv;
 });
 


### PR DESCRIPTION
Closes #121 and https://github.com/mapbox/mapbox-gl-js/issues/4568

Updated the link resolution to explicitly handle link tags with `#` characters because they are not preserved when passed through the `GithubSlug` module

