### PR TITLE
match sentry/browser version with dr-ui; pass `section` to Feedback

### DIFF
--- a/docs/components/api/api-page-items.js
+++ b/docs/components/api/api-page-items.js
@@ -52,6 +52,7 @@ class Section extends React.Component {
                     <ApiItem headingLevel={2} {...child} />
                 </div>
                 <Feedback
+                    section={child.name}
                     type={`section on ${child.name}`}
                     location={child.location}
                 />

--- a/docs/components/feedback.js
+++ b/docs/components/feedback.js
@@ -27,6 +27,7 @@ export default class Feedback extends React.Component {
                 user={this.state.user}
                 type={this.props.type}
                 webhook={constants.FORWARD_EVENT_WEBHOOK}
+                section={this.props.section || undefined}
             />
         );
     }
@@ -34,5 +35,6 @@ export default class Feedback extends React.Component {
 
 Feedback.propTypes = {
     location: PropTypes.object.isRequired,
-    type: PropTypes.string
+    type: PropTypes.string,
+    section: PropTypes.string
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@mapbox/prettier-config-docs": "^0.1.0",
     "@mapbox/remark-lint-link-text": "^0.4.5",
     "@mapbox/remark-lint-mapbox": "^0.10.2",
-    "@sentry/browser": "^5.13.0",
+    "@sentry/browser": "^5.15.5",
     "babel-eslint": "^10.0.3",
     "documentation": "~12.1.0",
     "downshift": "^5.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2697,16 +2697,6 @@
   dependencies:
     any-observable "^0.3.0"
 
-"@sentry/browser@^5.13.0":
-  version "5.13.2"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.13.2.tgz#fcca630c8c80447ba8392803d4e4450fd2231b92"
-  integrity sha512-4MeauHs8Rf1c2FF6n84wrvA4LexEL1K/Tg3r+1vigItiqyyyYBx1sPjHGZeKeilgBi+6IEV5O8sy30QIrA/NsQ==
-  dependencies:
-    "@sentry/core" "5.13.2"
-    "@sentry/types" "5.13.2"
-    "@sentry/utils" "5.13.2"
-    tslib "^1.9.3"
-
 "@sentry/browser@^5.15.5":
   version "5.16.0"
   resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.16.0.tgz#5e0786652fddb299f01be66835472960a56724be"
@@ -2715,17 +2705,6 @@
     "@sentry/core" "5.16.0"
     "@sentry/types" "5.16.0"
     "@sentry/utils" "5.16.0"
-    tslib "^1.9.3"
-
-"@sentry/core@5.13.2":
-  version "5.13.2"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.13.2.tgz#d89e199beef612d0a01e5c4df4e0bb7efcb72c74"
-  integrity sha512-iB7CQSt9e0EJhSmcNOCjzJ/u7E7qYJ3mI3h44GO83n7VOmxBXKSvtUl9FpKFypbWrsdrDz8HihLgAZZoMLWpPA==
-  dependencies:
-    "@sentry/hub" "5.13.2"
-    "@sentry/minimal" "5.13.2"
-    "@sentry/types" "5.13.2"
-    "@sentry/utils" "5.13.2"
     tslib "^1.9.3"
 
 "@sentry/core@5.16.0":
@@ -2739,15 +2718,6 @@
     "@sentry/utils" "5.16.0"
     tslib "^1.9.3"
 
-"@sentry/hub@5.13.2":
-  version "5.13.2"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.13.2.tgz#875a5ba983d6ada5caae5b6b4decd0257ef5cdb7"
-  integrity sha512-/U7yq3DTuRz8SRpZVKAaenW9sD2F5wbj12kDVPxPnGspyqhy0wBWKs9j0YJfBiDXMKOwp3HX964O3ygtwjnfAw==
-  dependencies:
-    "@sentry/types" "5.13.2"
-    "@sentry/utils" "5.13.2"
-    tslib "^1.9.3"
-
 "@sentry/hub@5.16.0":
   version "5.16.0"
   resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.16.0.tgz#99bea03969ac66291ad2dff8a6e2ccb19d7ed109"
@@ -2755,15 +2725,6 @@
   dependencies:
     "@sentry/types" "5.16.0"
     "@sentry/utils" "5.16.0"
-    tslib "^1.9.3"
-
-"@sentry/minimal@5.13.2":
-  version "5.13.2"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.13.2.tgz#e42e33dc74fc935f8857d1a43a528afd741640fd"
-  integrity sha512-VV0eA3HgrnN3mac1XVPpSCLukYsU+QxegbmpnZ8UL8eIQSZ/ZikYxagDNlZbdnmXHUpOEUeag2gxVntSCo5UcA==
-  dependencies:
-    "@sentry/hub" "5.13.2"
-    "@sentry/types" "5.13.2"
     tslib "^1.9.3"
 
 "@sentry/minimal@5.16.0":
@@ -2775,23 +2736,10 @@
     "@sentry/types" "5.16.0"
     tslib "^1.9.3"
 
-"@sentry/types@5.13.2":
-  version "5.13.2"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.13.2.tgz#8e68c31f8fb99b4074374bff13ed01035b373d8c"
-  integrity sha512-mgAEQyc77PYBnAjnslSXUz6aKgDlunlg2c2qSK/ivKlEkTgTWWW/dE76++qVdrqM8SupnqQoiXyPDL0wUNdB3g==
-
 "@sentry/types@5.16.0":
   version "5.16.0"
   resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.16.0.tgz#6f5fc48e4f2f5d94bbd7331cac42a4734f4cc02b"
   integrity sha512-VQB/zPfPz5yEXNLAv0lov+p3gt+YPBuExz7n33OuXAgvDedxzYfC1066Y6YM/ryBwwl6TDTV3M6JTDEYu3pulA==
-
-"@sentry/utils@5.13.2":
-  version "5.13.2"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.13.2.tgz#441594f4f9412bfd1690739ce986bf3a49687806"
-  integrity sha512-LwPQl6WRMKEnd16kg35HS3yE+VhBc8vN4+BBIlrgs7X0aoT+AbEd/sQLMisDgxNboCF44Ho3RCKtztiPb9blqg==
-  dependencies:
-    "@sentry/types" "5.13.2"
-    tslib "^1.9.3"
 
 "@sentry/utils@5.16.0":
   version "5.16.0"


### PR DESCRIPTION
This fixes two issue with the Feedback module:

- fix missing `url` tag. I believe this is due to this repo being on a different version of sentry/browser than dr-ui. (We should make this a peer dependency of dr-ui, ref https://github.com/mapbox/dr-ui/issues/285.)
- fix missing `section` for pages with multiple feedback components on the page. This is something I missed during QA (I'll add this to the checklist). 

How to test:
1. Visit /mapbox-gl-js/api/properties/ on staging (a page with sections).
2. Submit feedback.
3. Check docs-feedback Sentry project to make sure the `url` and `section` is included in the Sentry issue.

Fixes https://github.com/mapbox/documentation/issues/477