### PR TITLE
Add MTS to Expressions SDK Support table

### DIFF
--- a/docs/components/sdk_support_table.js
+++ b/docs/components/sdk_support_table.js
@@ -32,6 +32,9 @@ export default class SDKSupportTable extends React.Component {
                             <td style={{ borderTopRightRadius: '4px' }}>
                                 macOS SDK
                             </td>
+                            <td style={{ borderTopRightRadius: '4px' }}>
+                                Mapbox Tiling Service (MTS)
+                            </td>
                         </tr>
                     </thead>
                     <tbody>
@@ -43,6 +46,7 @@ export default class SDKSupportTable extends React.Component {
                                     <td>{this.support(entry, 'android')}</td>
                                     <td>{this.support(entry, 'ios')}</td>
                                     <td>{this.support(entry, 'macos')}</td>
+                                    <td>{this.support(entry, 'mts')}</td>
                                 </tr>
                             )
                         )}

--- a/docs/pages/style-spec/sources.md
+++ b/docs/pages/style-spec/sources.md
@@ -85,7 +85,8 @@ https://github.com/mapbox/mapbox-gl-js/blob/master/src/style-spec/reference/v8.j
             js: '0.10.0',
             android: '2.0.1',
             ios: '2.0.0',
-            macos: '0.1.0'
+            macos: '0.1.0',
+            mts: '1.0.0'
         }
     }}
 />
@@ -121,7 +122,8 @@ https://github.com/mapbox/mapbox-gl-js/blob/master/src/style-spec/reference/v8.j
             js: '0.10.0',
             android: '2.0.1',
             ios: '2.0.0',
-            macos: '0.1.0'
+            macos: '0.1.0',
+            mts: '1.0.0'
         }
     }}
 />


### PR DESCRIPTION
This adds MTS to Expressions SDK Support table. 

See this ticket for more details: https://github.com/mapbox/tilesets-api-team/issues/191
Style spec update PR: https://github.com/mapbox/mapbox-gl-js/pull/9816