### PR TITLE
Bump directions plugin version

### DIFF
--- a/docs/pages/example/mapbox-gl-directions.html
+++ b/docs/pages/example/mapbox-gl-directions.html
@@ -1,7 +1,7 @@
-<script src="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v4.0.2/mapbox-gl-directions.js"></script>
+<script src="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v4.1.0/mapbox-gl-directions.js"></script>
 <link
     rel="stylesheet"
-    href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v4.0.2/mapbox-gl-directions.css"
+    href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-directions/v4.1.0/mapbox-gl-directions.css"
     type="text/css"
 />
 <div id="map"></div>


### PR DESCRIPTION
Updates directions plugin example to use [latest release](https://github.com/mapbox/mapbox-gl-directions/releases/tag/v4.1.0)