### PR TITLE
Add link to style spec

### DIFF
--- a/docs/pages/example/3d-extrusion-floorplan.md
+++ b/docs/pages/example/3d-extrusion-floorplan.md
@@ -1,6 +1,6 @@
 ---
 title: Extrude polygons for 3D indoor mapping
-description: Create a 3D indoor map with the fill-extrude-height paint property.
+description: Create a 3D indoor map with the [`fill-extrude-height`](/mapbox-gl-js/style-spec/layers/#paint-fill-extrusion-fill-extrusion-height) paint property.
 tags:
   - layers
 thumbnail: 3d-extrusion-floorplan


### PR DESCRIPTION
When I notice Examples that mention specific properties covered in our Style Specification...
...I like to add links to our existing Style Spec docs!

(This is meant to reduce negative feedback related to examples not providing enough context.)