### PR TITLE
Link to Geocoding API docs in example description

### DIFF
--- a/docs/pages/example/mapbox-gl-geocoder.md
+++ b/docs/pages/example/mapbox-gl-geocoder.md
@@ -2,7 +2,7 @@
 title: Add a geocoder
 description: >-
   Use the [mapbox-gl-geocoder](https://github.com/mapbox/mapbox-gl-geocoder)
-  control to search for places using Mapbox Geocoding API.
+  control to search for places using the [Mapbox Geocoding API](/api/search/#geocoding).
   Check out our [Search Playground](https://www.mapbox.com/search-playground/) to explore geocoding query parameters and how they affect the results.
 tags:
   - controls-and-overlays


### PR DESCRIPTION
Closes https://github.com/mapbox/mapbox-gl-js-docs/issues/387

Adding this hyperlink may help this user find their own answer in Geocoding API docs.