### PR TITLE
Update hover-styles.html

### DIFF
--- a/docs/pages/example/hover-styles.html
+++ b/docs/pages/example/hover-styles.html
@@ -48,7 +48,7 @@
         // feature state for the feature under the mouse.
         map.on('mousemove', 'state-fills', function (e) {
             if (e.features.length > 0) {
-                if (hoveredStateId) {
+                if (hoveredStateId !== null) {
                     map.setFeatureState(
                         { source: 'states', id: hoveredStateId },
                         { hover: false }
@@ -65,7 +65,7 @@
         // When the mouse leaves the state-fill layer, update the feature state of the
         // previously hovered feature.
         map.on('mouseleave', 'state-fills', function () {
-            if (hoveredStateId) {
+            if (hoveredStateId !== null) {
                 map.setFeatureState(
                     { source: 'states', id: hoveredStateId },
                     { hover: false }


### PR DESCRIPTION
The example fails when an ID of a feature is zero (0), such that the hover state does not clear. This fix does a strict check against exactly null (matching what is set in lines 9 and 74) rather than a falsey check.